### PR TITLE
Fix resistance type handling

### DIFF
--- a/src/Effects/ResistanceUI.tsx
+++ b/src/Effects/ResistanceUI.tsx
@@ -9,7 +9,7 @@ function ResistanceUI({ effect, onEffectFieldChange }: GeneralEffectUIProps) {
     <div className="resistance-ui spacing">
       <ResistancePicker
         value={effect.resistanceType}
-        onChange={(val) => onEffectFieldChange('amountValue', val)}
+        onChange={(val) => onEffectFieldChange('resistanceType', val)}
       />
       <FrequencyPicker
         value={effect.frequency}


### PR DESCRIPTION
## Summary
- ensure selected resistance type stores into `resistanceType` field

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685031267c78832ea029fe3cc9efcfb8