### PR TITLE
Add override for utility effects

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,20 @@
+import js from '@eslint/js';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { sourceType: 'module' },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+    },
+  },
+];

--- a/src/Effects/Common.tsx
+++ b/src/Effects/Common.tsx
@@ -83,6 +83,22 @@ export function ValueInput({ label, value, onChange }: { label: string; value: n
   );
 }
 
+// Generic numeric input that allows any value (including negatives). Useful for
+// optional overrides or future numeric fields that shouldn't be clamped.
+export function NumberInput({ label, value, onChange }: { label: string; value: number; onChange: (value: number) => void }) {
+  return (
+    <div className="effect-field">
+      <InputLabel>{label}</InputLabel>
+      <TextField
+        type="number"
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        variant="standard"
+      />
+    </div>
+  );
+}
+
 // Power Level Picker
 export function PowerLevelPicker({ value, onChange }: { value: number; onChange: (value: number) => void }) {
   return (

--- a/src/Effects/UtilityUI.tsx
+++ b/src/Effects/UtilityUI.tsx
@@ -4,6 +4,7 @@ import {
   FrequencyPicker,
   ComplexityPicker,
   PowerLevelPicker,
+  NumberInput,
   GeneralEffectUIProps
 } from './Common';
 function UtilityUI({ effect, onEffectFieldChange }: GeneralEffectUIProps) {
@@ -29,6 +30,13 @@ function UtilityUI({ effect, onEffectFieldChange }: GeneralEffectUIProps) {
         value={effect.powerLevel}
         onChange={(val) => onEffectFieldChange('powerLevel', val)}
       />
+      {['Low utility', 'Medium utility', 'High utility'].includes(effect.effectType) && (
+        <NumberInput
+          label="Override"
+          value={effect.scoreOverride}
+          onChange={(val) => onEffectFieldChange('scoreOverride', val)}
+        />
+      )}
     </div>
   );
 }

--- a/src/dcCalculations.ts
+++ b/src/dcCalculations.ts
@@ -152,7 +152,8 @@ function calculateUtilityDC(effect: Effect): number {
   const compMod = getComplexityMod(effect.complexity);
 
   const partialDC = (effect.baseValue * pwrMod * freqMod * compMod) + dice;
-  return partialDC;
+  // Allow manual adjustments via scoreOverride for utility effects
+  return partialDC + effect.scoreOverride;
 }
 
 function calculatePlusXItemDC(effect: Effect): number {

--- a/src/values.ts
+++ b/src/values.ts
@@ -25,6 +25,12 @@ export interface Effect {
   unarmed: boolean;
   outsideClass: boolean;
   description: string;
+  /**
+   * Optional modifier applied after the normal DC calculation. Can be
+   * positive or negative and is primarily used by utility effects but
+   * kept generic so other effect types can leverage it in the future.
+   */
+  scoreOverride: number;
 }
 
 export interface ShardState {
@@ -130,6 +136,7 @@ export const defaultEffectState: Effect = {
   unarmed: false,
   outsideClass: false,
   description: 'Effect description here',
+  scoreOverride: 0,
 };
 
 export const initialShardState: ShardState[] = values.shardValues.map((shardObject) => ({


### PR DESCRIPTION
## Summary
- support ESLint 9 with new config
- allow numeric overrides via `NumberInput`
- expose override input for Low/Medium/High utilities
- apply override in calculation logic
- persist override in effect state

## Testing
- `npm run build`
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68790c0de4d8832eb21f61629ca55321