### PR TITLE
[codex] disable plant tracker zoom

### DIFF
--- a/app/plants/page.tsx
+++ b/app/plants/page.tsx
@@ -1,9 +1,18 @@
+import type { Metadata, Viewport } from 'next';
+
 import { PlantsView } from '@/plants/components';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Plant Tracker | Drew Taylor',
   description:
     'Track watering, fertilizer, notes, vibe checks, and replanting cycles for your plants.',
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default function PlantsPage() {

--- a/src/features/plants/components/PlantsView.module.scss
+++ b/src/features/plants/components/PlantsView.module.scss
@@ -1,12 +1,21 @@
 @use '../styles/tokens' as *;
 
 .page {
-  max-width: 40rem;
   margin: 0 auto;
+  max-width: 40rem;
+  width: 100%;
+  overflow-x: hidden;
   padding: 1.75rem 1.1rem 4rem;
   display: flex;
   flex-direction: column;
   gap: 1.4rem;
+  touch-action: pan-y;
+
+  input,
+  select,
+  textarea {
+    font-size: 1rem;
+  }
 }
 
 .topBar {


### PR DESCRIPTION
## What changed

Disabled zoom behavior for the plant tracker experience only.

- Added route-level viewport metadata for `/plants` with a fixed initial/maximum scale and `user-scalable=no`.
- Added plant page CSS guards to prevent horizontal overflow, limit touch gestures to vertical panning, and keep plant tracker form controls at `1rem` so mobile Safari does not auto-zoom focused text fields.

## Why

The plant tracker could zoom when focusing text boxes, and manual zooming could create awkward horizontal side scrolling. The root cause was a combination of mobile viewport scaling and plant tracker controls rendering below Safari's 16px auto-zoom threshold.

## Validation

- `npm run lint` equivalent via local ESLint binary
- `npm run type-check` equivalent via local TypeScript binary
- `npm run test` equivalent via local Vitest binary, 132 tests passed
- `npm run docs:validate`, including OpenAPI build and `swagger-cli validate`
- Verified the running `/plants` page served `width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no` and compiled plant CSS for overflow/touch/form-control sizing

Note: the in-app Browser automation failed to initialize in this Windows sandbox, so runtime verification used the local Next server response instead.